### PR TITLE
Fix typo on title

### DIFF
--- a/source/localizable/index.en.html.erb
+++ b/source/localizable/index.en.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Free Open-Source participatory democracy for cities and organizations | Decidi
+title: Free Open-Source participatory democracy for cities and organizations | Decidim
 description:
 ---
 <%= partial "/partials/index" %>


### PR DESCRIPTION
This causes a weird result in Google:

![](https://i.imgur.com/KUQrMtl.png)