### PR TITLE
Link to docs.decidim.org for Features and Roadmap and Admin Manual

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -48,3 +48,8 @@ end
 
 # Features page
 activate :asciidoc, layout: :asciidoc
+
+# 301 redirects
+redirect "docs/features-and-roadmap",    to: "https://docs.decidim.org/features/en/general-description/"
+redirect "ca/docs/features-and-roadmap", to: "https://docs.decidim.org/features/ca/general-description/"
+redirect "es/docs/features-and-roadmap", to: "https://docs.decidim.org/features/es/general-description/"

--- a/source/localizable/docs.ca.html.erb
+++ b/source/localizable/docs.ca.html.erb
@@ -8,15 +8,15 @@ description: Documentació del projecte Decidim
 
     <h2>Documentació tècnica i funcional</h2>
     <ul>
-      <li>Barandiaran, X. &amp; Romero, C. (2017) <a href="/ca/docs/features-and-roadmap">Funcionalitats i Roadmap Decidim 2017-2018</a></li>
+      <li>Barandiaran, X. &amp; Romero, C. (2017) <a href="https://docs.decidim.org/features/ca/general-description/">Funcionalitats i Roadmap Decidim 2017-2018</a></li>
       <li><a href="https://github.com/Platoniq/decidim-install">Guia d'instal·lació (no oficial)</a>.
         Una guia detallada per instal·lar una instància de producció de Decidim, aportada per l'Ivan Vergés de <a href="http://platoniq.net/">Platoniq</a>.</li>
     </ul>
 
     <h2>Manuals</h2>
     <ul>
-      <li>Manual d'ús [DISPONIBLE EN BREU]</li>
-      <li><a href="/pdf/Decidim_AdminManual_CA_0.10.pdf">Manual d'administració</a></li>
+      <li><a href="https://docs.decidim.org/deploy-and-admin/ca/get-decidim/">Manual d'administració</a></li>
+      <li><a href="https://docs.decidim.org/develop/en/introduction/">Developer's manual</a></li>
     </ul>
 
     <h2>Vídeos</h2>

--- a/source/localizable/docs.es.html.erb
+++ b/source/localizable/docs.es.html.erb
@@ -8,15 +8,15 @@ description: Documentación del proyecto decidim
 
     <h2>Documentación técnica y funcional</h2>
     <ul>
-      <li>Barandiaran, X. &amp; Romero, C. (2017) <a href="/es/docs/features-and-roadmap">Funcionalidades y Roadmap Decidim 2017-2018</a></li>
+      <li>Barandiaran, X. &amp; Romero, C. (2017) <a href="https://docs.decidim.org/features/es/general-description/">Funcionalidades y Roadmap Decidim 2017-2018</a></li>
       <li><a href="https://github.com/Platoniq/decidim-install">Guía de instalación (no oficial)</a>.
         Una guía detallada para instalar una instancia de producción de Decidim, aportada por Ivan Vergés de <a href="http://platoniq.net/">Platoniq</a>.</li>
     </ul>
 
     <h2>Manuales</h2>
     <ul>
-      <li>Manual de uso [DISPONIBLE EN BREVE]</li>
-      <li><a href="/pdf/Decidim_AdminManual_ES_0.10.pdf">Manual de administración</a></li>
+      <li><a href="https://docs.decidim.org/deploy-and-admin/es/get-decidim/">Manual de administración</a></li>
+      <li><a href="https://docs.decidim.org/develop/en/introduction/">Developer's manual</a></li>
     </ul>
 
     <h2>Vídeos</h2>

--- a/source/localizable/docs.html.erb
+++ b/source/localizable/docs.html.erb
@@ -8,15 +8,15 @@ description: Documentation about Decidim Project
 
     <h2>Technical and functional documentation</h2>
     <ul>
-      <li>Barandiaran, X. &amp; Romero, C. (2017) <a href="/docs/features-and-roadmap">Functionalities and Roadmap Decidim 2017-2018</a></li>
+      <li>Barandiaran, X. &amp; Romero, C. (2017) <a href="https://docs.decidim.org/features/en/general-description/">Functionalities and Roadmap Decidim 2017-2018</a></li>
       <li><a href="https://github.com/Platoniq/decidim-install">Installation Guide (Unofficial)</a>.
         A detailed guide for installing a production Decidim instance, contributed by Ivan Vergés from <a href="http://platoniq.net/">Platoniq</a>.</li>
     </ul>
 
     <h2>Manuals</h2>
     <ul>
-      <li>User manual [AVAILABLE SOON]</li>
-      <li><a href="/pdf/Decidim_AdminManual_EN_0.10.pdf">Administration manual</a></li>
+      <li><a href="https://docs.decidim.org/deploy-and-admin/en/get-decidim/">Administration manual</a></li>
+      <li><a href="https://docs.decidim.org/develop/en/introduction/">Developer's manual</a></li>
     </ul>
 
     <h2>Videos</h2>


### PR DESCRIPTION
It doesn't make sense to have the same content in two places (decidim.org and docs.decidim.org). This fixes problem with images in Features and Roadmap doc.

Replace the following docs linked from https://decidim.org/docs:

* Features and Roadmap doc, replace content handled by Middleman to a link do docs.decidim.org.
* Admin Manual, replace PDF to link link to docs.decdidim.org.

Add Middleman redirect rules to preserve old Features and Roadmap URLs.