### PR TITLE
Fix a double colon resulting in a missing translation

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -119,7 +119,7 @@ en:
       title: 'Components'
       subtitle: 'For participants and spaces to interact'
     other:
-      subtitle::
+      subtitle:
         'Dare to combine the components. Design and deploy a powerful democratic
         system in an easy way and adapt it to your organization’s needs'
     cta:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -68,7 +68,7 @@ en:
   # Community
   community:
     title: 'Metadecidim, our community'
-    subitlt: 'A democratic community that manages the Decidim project in all its dimensions'
+    subtitle: 'A democratic community that manages the Decidim project in all its dimensions'
     intro: 'Metadecidim is a community that collaborates in the design of the platform and the construction of the project. Together we can design and develop new features and report bugs for continuous improvement of the platform.'
     cta: 'Get started'
     features:


### PR DESCRIPTION
Related issue: #244

Seems like [8df0025](https://github.com/decidim/decidim.org/commit/8df0025336a391c7fb552b6ce3e0cabc05ab5936) introduced a typo in the English locale files which breaks one locale for the three languages.

This PR fixes it.