### PR TITLE
Add privacy policy acceptance checkbox in contact form

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -116,6 +116,14 @@ en:
     email: Email
     subject: Subject
     message: Message
+    privacy_policy:
+      accept: I accept the <a href="%{privacy_policy_url}">Privacy Policy</a>
+      message: >-
+        <p>When people contact Us by the contact form, email or similar communication means, we will automatically
+        collect the following information: name, entity, email address and the content of the User message in order
+        to attend your comments, requests, suggestions, etc.</p> <p>Additionally, we may process this data for
+        statistical studies through pseudonymization and even anonymization techniques, such as data aggregation,
+        preventing this subsequent processing from identifying Users individually.</p>
     send: Send
 
   thanks:

--- a/source/localizable/contact.html.erb
+++ b/source/localizable/contact.html.erb
@@ -32,6 +32,11 @@ description:
         <label for="message"><%= t('contact.message') %> <span class="required" aria-label="required field">*</span></label>
         <textarea id="message" name="message" required></textarea>
       </div>
+      <div>
+        <input type="checkbox" id="accept_privacy_policy" name="accept_privacy_policy" required/>
+        <label for="accept_privacy_policy"><%= t('contact.privacy_policy.accept', privacy_policy_url: "#{t(:path)}/privacy-policy") %></label>
+      </div>
+      <p><%= t('contact.privacy_policy.message') %></p>
       <div class="form-field">
         <button type="submit" class="btn btn--primary"><%= t('contact.send') %></button>
       </div>


### PR DESCRIPTION
Add a required checkbox with a mesage for accepting the privacy policy in the contact form. 

Screenshot:

![Selection_072](https://user-images.githubusercontent.com/717367/159257859-a0b44782-e350-4cb4-a6cc-e7817eee18a9.png)
