### PR TITLE
Fix missing translation on used_by.filters

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -129,6 +129,7 @@ ignore_unused:
   - 'partnership-policy.explanation.{p1,p2,p3}'
   - 'press.links.*.{title,link}'
   - '{legal-notice,privacy-policy}.*.{title,paragraph}'
+  - 'used_by.filters.*'
   - 'trademark.{p1,p2,p3}'
   - 'trademark.goals.{l1,l2,l3}'
   - 'trademark.{examples-1,examples-2,examples-3}.{title,l1,l2,l3}'

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -587,6 +587,11 @@ en:
       f9: meetings
       subtitle: Decidim keeps growing and being adopted by organizations and the community.
       title: Facts & Figures
+    filters:
+      f0: See all
+      f1: Government
+      f2: Cities
+      f3: NGOs
     intro: You can use Decidim in a public or private organisation, with hundreds or thousands of potential participants, such as a city council, an association, a university, an NGO, a trade union, a neighbourhood collective or a cooperative...
     join: Over 400 entities, 250 governamental and 150 grass root communities have chosen Decidim for their democratic processes.
     subtitle: These cities, regions and organizations are already using Decidim


### PR DESCRIPTION
After introducing i18n-tasks I've broken a translation in /usedby

This PR fixes it