### PR TITLE
Change link on footer from 'Use cases' to 'Used by'

### DIFF
--- a/data/links.yml
+++ b/data/links.yml
@@ -3,8 +3,8 @@ decidim:
     url: /first-steps
   - name: nav.features
     url: /features
-  - name: nav.use-cases
-    url: /tags/casestudy
+  - name: nav.used_by
+    url: /usedby
   - name: nav.demo
     url: https://try.decidim.org/
   - name: nav.modules


### PR DESCRIPTION
Yesterday we've made a quick usability testing and noticed that it was difficult to arrive to the "Used by" page. We're adding it to the footer and dropping the "Use cases" link. 