### PR TITLE
Change 'Demo' CTA button to 'Donate'

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -424,6 +424,7 @@ en:
     docs:
       path: https://docs.decidim.org/
       title: Documentation
+    donate: Donate
     faqs: FAQs
     features: Features
     first-steps: First steps

--- a/source/partials/header.html.erb
+++ b/source/partials/header.html.erb
@@ -24,7 +24,7 @@
         <%= link_to t('nav.community'), "#{t(:path)}/community", class: "inline-block py-4 w-full md:w-auto" %>
         <%= link_to t('nav.about'), "#{t(:path)}/about", class: "inline-block py-4 w-full md:w-auto" %>
       </div>
-      <%= link_to t('nav.demo'), "https://try.decidim.org/", target: "_blank", rel: "noopener noreferrer", class: "button inline-block text-center py-4 w-full md:w-auto" %>
+      <%= link_to t('nav.donate'), "http://donate.decidim.org/", target: "_blank", rel: "noopener noreferrer", class: "button inline-block text-center py-4 w-full md:w-auto" %>
       <%= partial "/partials/language-selector" %>
     </nav>
   </div>


### PR DESCRIPTION
We're starting a fund raising campaign, so we'll change the CTA button from "Demo" to "Donate" (at least temporarily). 