### PR TITLE
Reorganize 'Press kit' section in Press page

### DIFF
--- a/data/press.yml
+++ b/data/press.yml
@@ -35,9 +35,11 @@ kit:
     url: https://decidim.org/pdf/identity-manual-ca.pdf
   - icon: ri-movie-2-line
     url: https://www.youtube.com/watch?v=f6JMgJAQ2tc
-  - icon: ri-vidicon-2-line
-    url: https://meta.decidim.org/conferences/DecidimFest21
-  - icon: ri-video-line
-    url: https://www.youtube.com/channel/UCbxXpC5MmKImcGFzUJxdAUw
   - icon: ri-map-2-line
     url: https://decidim.org/pdf/Decidim_Triptic_EN.pdf
+  - icon: ri-vidicon-2-line
+    url: https://meta.decidim.org/conferences
+  - icon: ri-video-line
+    url: https://www.youtube.com/channel/UCbxXpC5MmKImcGFzUJxdAUw
+  - icon: ri-book-read-line
+    url: https://zotero.org/groups/1607464/metadecidim/collections/DWR7CKGM

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -484,17 +484,17 @@ en:
         link: Watch
         title: Promotional spot
       link3:
-        link: To the site
-        title: Decidim Fest 2021
-      link4:
-        link: Youtube channel
-        title: Videos
-      link5:
         link: Download
         title: Brochure
+      link4:
+        link: To the site
+        title: Decidim Fest
+      link5:
+        link: Youtube channel
+        title: Videos
       link6:
-        link: Downloads
-        title: Community photos
+        link: Zotero repository
+        title: Academic papers
     sign_up: Sign up for our newsletter on Metadecidim
     social_media: Find us on social media
     subtitle: For media enquiries, please send us an email at


### PR DESCRIPTION
Fix #334 

As it says there:

> Right now the 'Press kit' section is outdated and it looks like this:
![image](https://user-images.githubusercontent.com/23509895/222674479-562aa8a1-07c0-4f64-b9df-3b50a238f467.png)
>
> We should modify it so that it is displayed like this:
![image](https://user-images.githubusercontent.com/23509895/222674732-64652c80-f3f0-488c-b507-78cd26a4006e.png)

# Acceptance criteria 

- [ ] Change the order
- [ ] Change the link to point to all Decidim Fest editions: https://meta.decidim.org/conferences
- [ ] Add access to the Zotero repository: https://www.zotero.org/groups/1607464/metadecidim/collections/DWR7CKGM
 `<use xlink:href="/images/remixicon.symbol.svg#ri-book-read-line"></use>`
