### PR TITLE
Reorganize footer section 'Stay up to date'

### DIFF
--- a/data/links.yml
+++ b/data/links.yml
@@ -25,14 +25,16 @@ about_us:
     url: /partners
   - name: nav.faqs
     url: /faqs
-  - name: nav.press
-    url: /press
   - name: nav.contact
     url: /contact
 
 stay_up_to_date:
   - name: nav.blog
     url: /blog
+  - name: nav.press
+    url: /press
+  - name: nav.academy
+    url: https://www.zotero.org/groups/1607464/metadecidim/collections/DWR7CKGM
 
 legal:
   - name: nav.legal-notice

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -413,6 +413,7 @@ en:
     title: Modules
   nav:
     about: About
+    academy: Academy
     association: Association
     blog: Blog
     close_menu: Close menu


### PR DESCRIPTION
Fix #333 

As it says there:

> To make it easier to find information about Decidim and what is written about the project in general, we should reorganise the 'Stay up to date' section with the following items:
> * Blog
> * Press (move it from About us to Stay up to date)
> * Academy, with link to all the documentation collected in the Zotero repository: https://www.zotero.org/groups/1607464/metadecidim/collections/DWR7CKGM
>
> ![image](https://user-images.githubusercontent.com/23509895/222673866-cf9a76b9-d0d7-468b-a43b-f6f6cff31e0f.png)
