### PR TITLE
Fix rubocop offense and add URL validation for installations

### DIFF
--- a/source/admin/config.yml
+++ b/source/admin/config.yml
@@ -34,7 +34,7 @@ collections:
         file: "data/alert.yml"
         fields:
           - { label: 'Enabled', name: 'enabled', widget: 'boolean', default: true, required: true}
-          - { label: 'URL', name: 'url', widget: 'string', required: true }
+          - { label: 'URL', name: 'url', widget: 'string', required: true, pattern: ['.{12,}^(http|https)://', "Must be an URL and starts with http:// or https://"]  }
   - name: "post"
     label: "Post"
     folder: "source/blog/en"

--- a/spec/lib/facts_helpers_spec.rb
+++ b/spec/lib/facts_helpers_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe FactsHelpers do
   describe "#get_statistic_for_fact" do
     subject { get_statistic_for_fact(data_type, fallback, data) }
 
-    let(:fallback) { 123 }
-
     Installation = Struct.new(:id, :type, :url, keyword_init: true)
+
+    let(:fallback) { 123 }
 
     let(:data) do
       Struct.new(:installations, :countries, keyword_init: true).new(

--- a/spec/lib/facts_helpers_spec.rb
+++ b/spec/lib/facts_helpers_spec.rb
@@ -10,13 +10,15 @@ RSpec.describe FactsHelpers do
 
     let(:fallback) { 123 }
 
+    Installation = Struct.new(:id, :type, :url, keyword_init: true)
+
     let(:data) do
-      OpenStruct.new(
+      Struct.new(:installations, :countries, keyword_init: true).new(
         installations: [
-          ["i1", { "type" => "org", "url" => "https://example.org" }],
-          ["i2", { "type" => "city", "url" => "https://example.es" }],
-          ["i3", { "type" => "city", "url" => "https://example.cat" }],
-          ["i4", { "type" => "region", "url" => "https://example.fr" }]
+          [:installation1, Installation.new(id: "i1", type: "org", url: "https://example.org")],
+          [:installation2, Installation.new(id: "i2", type: "city", url: "https://example.es")],
+          [:installation3, Installation.new(id: "i3", type: "city", url: "https://example.cat")],
+          [:installation4, Installation.new(id: "i4", type: "region", url: "https://example.fr")]
         ],
         countries: %w(es fr)
       )


### PR DESCRIPTION
Pipeline is broken so this PR tries to fix it

I'm also adding a validation for the installation URLs. 