### PR TITLE
Fix rubocop antipattern configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 inherit_from:
-  - https://raw.githubusercontent.com/decidim/decidim/refs/heads/fix/rubocop-antipattern/decidim-dev/config/rubocop/ruby/configuration.yml
-  - https://raw.githubusercontent.com/decidim/decidim/refs/heads/fix/rubocop-antipattern/decidim-dev/config/rubocop/rspec/configuration.yml
+  - https://raw.githubusercontent.com/decidim/decidim/refs/heads/develop/decidim-dev/config/rubocop/ruby/configuration.yml
+  - https://raw.githubusercontent.com/decidim/decidim/refs/heads/develop/decidim-dev/config/rubocop/rspec/configuration.yml
 
 plugins:
   - rubocop-rspec


### PR DESCRIPTION
Ignores future rubcop `configuration.yml `

Points required configuration moved in upstream in `decidim/decidim`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated ignore rules to exclude certain environment/configuration files from version control.
  * Updated linting configuration to add Capybara checks and adjust upstream configuration sources for improved code-quality enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->