### PR TITLE
Update association's address in legal notice

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -322,8 +322,9 @@ en:
       title: Already using Decidim
   legal-notice:
     section-1:
-      paragraph: |
-        <p>You are accessing the website of Associació de Software Lliure Decidim ("Decidim", "Us" or "We") available through the web domain <a href="https://decidim.org">https://decidim.org/</a> (hereinafter, the "Website"), domiciled in Carrer Concepción Arenal 165, Number 165, Canòdrom - Ateneu d'Innovació Digital i Democràtica, Barcelona, postal code 08027, Spain and ID number G67401174.</p><p><b>You can contact us at: <a href="mailto:hola@decidim.org">hola@decidim.org</a></b></p>
+      paragraph: '<p>You are accessing the website of Associació de Software Lliure Decidim ("Decidim", "Us" or "We") available through the web domain <a href="https://decidim.org">https://decidim.org/</a> (hereinafter, the "Website"), domiciled in Carrer Concepción Arenal 165, Number 165, Canòdrom - Ateneu d''Innovació Digital i Democràtica, Barcelona, postal code 08027, Spain and ID number G67401174.</p><p><b>You can contact us at: <a href="mailto:hola@decidim.org">hola@decidim.org</a></b></p>
+
+        '
       title: Who we are
     section-2:
       paragraph: "<p>The purpose of this Website is to provide general information to the public about Decidim, its activities and technology, consisting in a free open-source participatory democracy platform for cities and organizations, and the management of the Decidim community generated around the world from our collaborative technology allowing the development of citizen and associative projects with greater social participation. You may freely test the Decidim platform with our online demo.</p> <p>The purpose of the terms of use of this Legal Notice is to govern the permitted use of this Website and the services and/or contents hosted in accordance with the Law 34/2002 on Information Society Services and Electronic Commerce and other applicable legal provisions.</p>"


### PR DESCRIPTION
Checking out the association's address, I see that we didn't update it. This PR fixes it.

It's on http://localhost:4567/legal-notice 

<img width="798" height="464" alt="image" src="https://github.com/user-attachments/assets/5570d847-84ff-4f3b-8f4e-58a6aaca9080" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the legal notice: revised the domiciled address to "Carrer Concepción Arenal 165, Number 165, Canòdrom - Ateneu d'Innovació Digital i Democràtica, Barcelona, 08027, Spain".
  * Reformatted the paragraph into a multi-line presentation for improved readability.
  * Contact email and section titles remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->