### PR TITLE
Fallback to `en` when strings are missing in locales

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -25,6 +25,16 @@ activate :i18n, mount_at_root: :en, langs: [:en, :es, :eu, :ca, :cs, :fr, :de, :
 
 activate :directory_indexes
 
+# Fallback to en when strings are missing in other locales
+ready do
+  I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
+  I18n.backend.extend(I18n::Backend::Fallbacks)
+  I18n.fallbacks = I18n::Locale::Fallbacks.new(
+    es: [:en], eu: [:en], ca: [:en], cs: [:en], fr: [:en],
+    de: [:en], hu: [:en], ja: [:en], "pt-BR": [:en], ro: [:en], fi: [:en]
+  )
+end
+
 # Reload the browser automatically whenever files change
 configure :development do
   activate :livereload

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -40,15 +40,19 @@ RSpec.describe I18n do
   context "with fallbacks enabled" do
     before do
       I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
-      described_class.backend.extend(I18n::Backend::Fallbacks)
-      described_class.fallbacks = I18n::Locale::Fallbacks.new(
+      I18n.backend.extend(I18n::Backend::Fallbacks)
+      I18n.fallbacks = I18n::Locale::Fallbacks.new(
         es: [:en], eu: [:en], ca: [:en], cs: [:en], fr: [:en],
         de: [:en], hu: [:en], ja: [:en], "pt-BR": [:en], ro: [:en], fi: [:en]
       )
-      described_class.default_locale = :en
+      I18n.default_locale = :en
     end
 
-    after { I18n.locale = :en }
+    after do
+      I18n.fallbacks = I18n::Locale::Fallbacks.new
+      I18n.default_locale = :en
+      I18n.locale = :en
+    end
 
     it "returns the localised string when the translation exists in the current locale" do
       expect(described_class.t("404.title", locale: :es)).not_to match(/translation missing/)

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -40,20 +40,7 @@ RSpec.describe I18n do
 
   context "with fallbacks enabled" do
     before do
-      I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
-      described_class.backend.extend(I18n::Backend::Fallbacks)
-      described_class.fallbacks = I18n::Locale::Fallbacks.new(
-        es: [:en], eu: [:en], ca: [:en], cs: [:en], fr: [:en],
-        de: [:en], hu: [:en], ja: [:en], "pt-BR": [:en], ro: [:en], fi: [:en]
-      )
-      described_class.default_locale = :en
       described_class.backend.store_translations(:en, fallback_test: { missing_key: "English fallback value" })
-    end
-
-    after do
-      described_class.fallbacks = I18n::Locale::Fallbacks.new
-      described_class.default_locale = :en
-      described_class.locale = :en
     end
 
     it "returns the localised string when the translation exists in the current locale" do

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe I18n do
       described_class.default_locale = :en
     end
 
-    after { I18n.locale = :en }
+    after { described_class.locale = :en }
 
     it "returns the localised string when the translation exists in the current locale" do
       expect(described_class.t("404.title", locale: :es)).not_to match(/translation missing/)

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -36,4 +36,30 @@ RSpec.describe I18n do
                     "Run `i18n-tasks check-consistent-interpolations' to show them"
     expect(inconsistent_interpolations).to be_empty, error_message
   end
+
+  context "with fallbacks enabled" do
+    before do
+      I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
+      I18n.backend.extend(I18n::Backend::Fallbacks)
+      I18n.fallbacks = I18n::Locale::Fallbacks.new(
+        es: [:en], eu: [:en], ca: [:en], cs: [:en], fr: [:en],
+        de: [:en], hu: [:en], ja: [:en], "pt-BR": [:en], ro: [:en], fi: [:en]
+      )
+      I18n.default_locale = :en
+    end
+
+    after { I18n.locale = :en }
+
+    it "returns the localised string when the translation exists in the current locale" do
+      expect(I18n.t("404.title", locale: :es)).not_to match(/translation missing/)
+    end
+
+    it "falls back to English when the translation is missing in the current locale" do
+      [:es, :eu, :ca, :cs, :fr, :de, :hu, :ja, :ro, :fi, :"pt-BR"].each do |locale|
+        expect(I18n.t("first-steps.section5.title", locale:))
+          .to eq(I18n.t("first-steps.section5.title", locale: :en)),
+              "Expected #{locale} to fall back to English for first-steps.section5.title"
+      end
+    end
+  end
 end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "i18n/tasks"
+require "i18n/backend/fallbacks"
 
 RSpec.describe I18n do
   let(:locales) do
@@ -46,6 +47,7 @@ RSpec.describe I18n do
         de: [:en], hu: [:en], ja: [:en], "pt-BR": [:en], ro: [:en], fi: [:en]
       )
       described_class.default_locale = :en
+      described_class.backend.store_translations(:en, fallback_test: { missing_key: "English fallback value" })
     end
 
     after do
@@ -60,9 +62,9 @@ RSpec.describe I18n do
 
     it "falls back to English when the translation is missing in the current locale" do
       [:es, :eu, :ca, :cs, :fr, :de, :hu, :ja, :ro, :fi, :"pt-BR"].each do |locale|
-        expect(described_class.t("first-steps.section5.title", locale:))
-          .to eq(described_class.t("first-steps.section5.title", locale: :en)),
-              "Expected #{locale} to fall back to English for first-steps.section5.title"
+        expect(described_class.t("fallback_test.missing_key", locale:))
+          .to eq("English fallback value"),
+              "Expected #{locale} to fall back to English for a missing key"
       end
     end
   end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -40,24 +40,24 @@ RSpec.describe I18n do
   context "with fallbacks enabled" do
     before do
       I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
-      I18n.backend.extend(I18n::Backend::Fallbacks)
-      I18n.fallbacks = I18n::Locale::Fallbacks.new(
+      described_class.backend.extend(I18n::Backend::Fallbacks)
+      described_class.fallbacks = I18n::Locale::Fallbacks.new(
         es: [:en], eu: [:en], ca: [:en], cs: [:en], fr: [:en],
         de: [:en], hu: [:en], ja: [:en], "pt-BR": [:en], ro: [:en], fi: [:en]
       )
-      I18n.default_locale = :en
+      described_class.default_locale = :en
     end
 
     after { I18n.locale = :en }
 
     it "returns the localised string when the translation exists in the current locale" do
-      expect(I18n.t("404.title", locale: :es)).not_to match(/translation missing/)
+      expect(described_class.t("404.title", locale: :es)).not_to match(/translation missing/)
     end
 
     it "falls back to English when the translation is missing in the current locale" do
       [:es, :eu, :ca, :cs, :fr, :de, :hu, :ja, :ro, :fi, :"pt-BR"].each do |locale|
-        expect(I18n.t("first-steps.section5.title", locale:))
-          .to eq(I18n.t("first-steps.section5.title", locale: :en)),
+        expect(described_class.t("first-steps.section5.title", locale:))
+          .to eq(described_class.t("first-steps.section5.title", locale: :en)),
               "Expected #{locale} to fall back to English for first-steps.section5.title"
       end
     end


### PR DESCRIPTION
Fallback has been implemented to present `en` strings in the case certain strings are missing in locales due to no translations available. Thus allowing the site to be presentable while undergoing a make over.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled automatic fallback to English for missing translations so non-English locales display English strings when local translations are absent.

* **Tests**
  * Added test coverage verifying that existing localized strings remain resolved and that missing keys in various locales (including regional variants) correctly return the English fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->