### PR TITLE
Fix extension format on blogs 

### DIFF
--- a/source/admin/config.yml
+++ b/source/admin/config.yml
@@ -26,7 +26,7 @@ collections:
     folder: "source/blog/en"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     summary: "{{title}} -- {{year}}-{{month}}-{{day}}"
-    extension: "md"
+    extension: "html.md"
     format: "yaml-frontmatter"
     create: true
     fields:


### PR DESCRIPTION
For a time being we had an issue where Sveltia wouldn't accept `html.md` and Middleman won't pick up plain `.md` files. 

Thanks to the fix: https://github.com/sveltia/sveltia-cms/issues/784 from Sveltia, blogs can now be created without errors to the formatter in the web, while still having access via the admin area of the CMS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated post file format configuration in content management settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->