### PR TITLE
Fix case studies index & page link

### DIFF
--- a/source/case-studies/en/barcelona-budgeting.html.md
+++ b/source/case-studies/en/barcelona-budgeting.html.md
@@ -1,5 +1,5 @@
 ---
-date: "2026-01-01"
+date: "2026-01-05"
 title: Participatory Budgets 2020-2023 in Barcelona
 subtitle: The first participatory budgets in the city, or how to promote democratic transparency and citizen empowerment
 website: https://www.decidim.barcelona/

--- a/source/case-studies/en/brazils-participatory-plurianual-plan-embedding-citizen-participation-in-federal-strategic-planning.html.md
+++ b/source/case-studies/en/brazils-participatory-plurianual-plan-embedding-citizen-participation-in-federal-strategic-planning.html.md
@@ -1,5 +1,5 @@
 ---
-date: "2026-01-01"
+date: "2026-01-04"
 title: 'Brazils Participatory Plurianual Plan: embedding citizen participation in federal strategic planning'
 subtitle: A strategic planning process that led to the launch of the Brasil Participativo platform
 website: https://brasilparticipativo.presidencia.gov.br/

--- a/source/case-studies/en/decidim-and-the-city-of-helsinki.html.md
+++ b/source/case-studies/en/decidim-and-the-city-of-helsinki.html.md
@@ -1,5 +1,5 @@
 ---
-date: "2026-01-01"
+date: "2026-01-02"
 title: Decidim and the city of Helsinki
 subtitle: An interview with Sanna Moisala, Project manager of participatory services at the The Helsinki City Executive Office. Digitalisation Unit.
 website: https://omastadi.hel.fi/?locale=en

--- a/source/case-studies/en/the-japanese-case.html.md
+++ b/source/case-studies/en/the-japanese-case.html.md
@@ -1,5 +1,5 @@
 ---
-date: "2026-01-01"
+date: "2026-01-03"
 title: The Japanese Case
 subtitle: The first Decidim instance in the Pacific island was deployed on the year 2020 at Kakogawa, later came Yosano, Nishiaizu, Kamaishi and the community instance Meta.
 website: https://kakogawa.diycities.jp/

--- a/source/case-studies/index.html.erb
+++ b/source/case-studies/index.html.erb
@@ -30,7 +30,7 @@ nav: case-studies
         <%= icon "ri-equalizer-line", class: "w-5 h-5" %>
         <span class="hidden md:inline"><%= t("case_studies.filters.title") %></span>
         <span data-cs-filter-badge class="hidden bg-red-500 text-white text-xs rounded-full w-4 h-4 flex justify-center font-medium"></span>
-        <%= icon "ri-arrow-up-s-line", class: "hidden md:block w-4 h-4 transition-transform data-[open]:rotate-180", "data-cs-filter-arrow" => true %>
+        <%= icon "ri-arrow-down-s-line", class: "hidden md:block w-4 h-4 transition-transform data-[open]:rotate-180", "data-cs-filter-arrow" => true %>
       </button>
       <div data-cs-filter-panel class="hidden absolute right-0 z-20 mt-2 w-72 bg-white border border-gray-50 rounded-2xl shadow-lg py-4">
         <div class="px-5 pb-3">

--- a/source/javascripts/filters.js
+++ b/source/javascripts/filters.js
@@ -168,7 +168,7 @@ const caseStudyFilter = () => {
 
     if (currentPage > 1) {
       appendBtn({
-        label: "Prev <i class=\"ri-arrow-left-line text-xl\"></i>",
+        label: "<svg class=\"w-5 h-5\" fill=\"currentColor\"><use xlink:href=\"/images/remixicon.symbol.svg#ri-arrow-left-line\"></use></svg> Prev",
         ariaLabel: "Previous page",
         onClick: () => filter.goToPage(currentPage - 1),
         cls: cssClasses.prev
@@ -203,7 +203,7 @@ const caseStudyFilter = () => {
 
     if (currentPage < totalPages) {
       appendBtn({
-        label: "Next <i class=\"ri-arrow-right-line text-xl\"></i>",
+        label: "Next <svg class=\"w-5 h-5\" fill=\"currentColor\"><use xlink:href=\"/images/remixicon.symbol.svg#ri-arrow-right-line\"></use></svg>",
         ariaLabel: "Next page",
         onClick: () => filter.goToPage(currentPage + 1),
         cls: cssClasses.next

--- a/source/javascripts/filters.js
+++ b/source/javascripts/filters.js
@@ -60,8 +60,8 @@ const caseStudyFilter = () => {
   const cssClasses = {
     pageActive: "w-9 h-9 rounded-full bg-red-100 text-red-500 font-semibold text-sm flex items-center justify-center",
     pageInactive: "w-9 h-9 rounded-full text-red-500 font-medium text-sm flex items-center justify-center hover:bg-gray-100 transition-colors",
-    prev: "flex items-center gap-2 px-5 py-2 rounded-lg border-2 border-red-400 text-red-500 font-medium text-sm hover:bg-red-50 transition-colors mr-3",
-    next: "flex items-center gap-2 px-5 py-2 rounded-lg border-2 border-red-400 text-red-500 font-medium text-sm hover:bg-red-50 transition-colors ml-3",
+    prev: "flex items-center gap-2 px-5 py-2 rounded-lg border border-red-400 text-red-500 font-medium text-sm hover:bg-red-50 transition-colors mr-3",
+    next: "flex items-center gap-2 px-5 py-2 rounded-lg border border-red-400 text-red-500 font-medium text-sm hover:bg-red-50 transition-colors ml-3",
     ellipsis: "w-9 h-9 flex items-center justify-center text-gray-400 text-sm",
     chip: "inline-flex items-center gap-1 border border-gray-100 bg-gray-100 rounded-lg px-3 py-1 par-sm font-bold text-gray-500",
     chipX: "pl-1 text-2xl font-bold text-gray-400 hover:text-gray-700 leading-none",

--- a/source/localizable/first-steps.html.erb
+++ b/source/localizable/first-steps.html.erb
@@ -94,7 +94,7 @@ description:
         <%= t("first-steps.section2.title") %>
       </h2>
       <div class="hidden md:block">
-        <%= partial "partials/arrow-link-rounded", locals: { text: t("first-steps.section2.link"), url: "#{t(:path)}/features" } %>
+        <%= partial "partials/arrow-link-rounded", locals: { text: t("first-steps.section2.link"), url: "#{t(:path)}/case-studies" } %>
       </div>
     </div>
     <p class="par-md md:py-6 pt-5 max-w-prose text-black">
@@ -106,7 +106,7 @@ description:
       <%= partial "/partials/case-study-cards", locals: { limit: 3 } %>
     </div>
     <div class="md:hidden pb-10">
-      <%= partial "partials/arrow-link-rounded", locals: { text: t("first-steps.section2.link"), url: "#{t(:path)}/features" } %>
+      <%= partial "partials/arrow-link-rounded", locals: { text: t("first-steps.section2.link"), url: "#{t(:path)}/case-studies" } %>
     </div>
   </div>
 </section>


### PR DESCRIPTION
The order of the index should follow according to what is detailed in the issue and screenshot. 

Also the link the `case-studies` page in the partial within the `first-steps` page was pointing to `features` which now points to the Case Studies page.

- Fixes: #451

<img width="1351" height="1029" alt="image" src="https://github.com/user-attachments/assets/faaae65c-d0c1-41eb-ab72-17b94ecc6060" />
