### PR TITLE
Fix padding testimonals on home page

### DIFF
--- a/source/localizable/index.html.erb
+++ b/source/localizable/index.html.erb
@@ -69,7 +69,9 @@ pageClass: home
   </div>
 </section>
 
-<%= partial "/partials/testimonials" %>
+<section class="md:py-10 py-6">
+  <%= partial "/partials/testimonials" %>
+</section>
 
 <section class="bg-red-100">
   <div class="container text-red-500 py-6 md:py-24">


### PR DESCRIPTION
This tiny patch solves an issue with padding on the testimonial partial on the homepage.

BEFORE: 
<img width="1321" height="660" alt="image" src="https://github.com/user-attachments/assets/78fef3fc-54d5-4757-b176-3ee6f2feb0a4" />

BEFORE MOBILE:
<img width="791" height="687" alt="image" src="https://github.com/user-attachments/assets/4b2da9a9-f80b-4628-b725-f12c64124b72" />


AFTER:
<img width="1321" height="660" alt="image" src="https://github.com/user-attachments/assets/ff897d66-5b78-4ab2-9815-2df0b4f02b0f" />

AFTER MOBILE:
<img width="791" height="687" alt="image" src="https://github.com/user-attachments/assets/2d533299-c815-4b41-98fd-e6f25caee571" />
