### PR TITLE
Devcontainer and lock files update

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION
 
 RUN wget -q -O /tmp/google-chrome-key.pub https://dl-ssl.google.com/linux/linux_signing_key.pub \
    && sudo gpg --dearmor -o /usr/share/keyrings/google-chrome-keyring.gpg /tmp/google-chrome-key.pub \
-   && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list \
+   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/google-chrome-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list \
    && sudo apt-get update \
    && sudo apt-get install -y google-chrome-stable libicu-dev \
    && sudo rm -rf /var/lib/apt/lists/* /tmp/google-chrome-key.pub

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ RUN wget -q -O /tmp/google-chrome-key.pub https://dl-ssl.google.com/linux/linux_
    && sudo gpg --dearmor -o /usr/share/keyrings/google-chrome-keyring.gpg /tmp/google-chrome-key.pub \
    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/google-chrome-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list \
    && sudo apt-get update \
-   && sudo apt-get install -y google-chrome-stable libicu-dev \
+   && sudo apt-get install -y --no-install-recommends google-chrome-stable \
    && sudo rm -rf /var/lib/apt/lists/* /tmp/google-chrome-key.pub
 
 ENV BINDING="0.0.0.0"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,11 @@
 ARG RUBY_VERSION=3.1.2
 FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION
 
+RUN wget -q -O /tmp/google-chrome-key.pub https://dl-ssl.google.com/linux/linux_signing_key.pub \
+   && sudo gpg --dearmor -o /usr/share/keyrings/google-chrome-keyring.gpg /tmp/google-chrome-key.pub \
+   && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list \
+   && sudo apt-get update \
+   && sudo apt-get install -y google-chrome-stable libicu-dev \
+   && sudo rm -rf /var/lib/apt/lists/* /tmp/google-chrome-key.pub
+
 ENV BINDING="0.0.0.0"

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.10.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e",
+      "integrity": "sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.1",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:94879eebb6a0e4e2f197de9f12db7427cb4a25b82d93c55239ce8c8fc394a1b4",
+      "integrity": "sha256:94879eebb6a0e4e2f197de9f12db7427cb4a25b82d93c55239ce8c8fc394a1b4"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "decidim.org",
+  "name": "decidim-org",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
While reviewing #441 I noticed some changes that need to be committed:

1. We need to add google-chrome to the devcontainer configuration so we can run the new specs with JS 
2. With latest versions of devcontainer there's a lockfile for checking the integrity of the versions 
3. The package-lock.json seems to follow new rules and now the `.` (dot character) isn't valid, so it uses a `-` (dash character)


### Testing

1. Run the following commands:
``` 
bin/devcontainer rebuild
# Then on a second terminal:
bin/devcontainer bash
bundle exec rspec spec/system/faqs_spec.rb
``` 
2. See that before this patch it fails, after the patch it works.
3. Do a git status and see the changes in the lock files